### PR TITLE
eliminate cursor highlighting on the canvas element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,3 @@
-
 body {
 	background: #e4e6e8;
 	background: -moz-linear-gradient(top,  #ffffff 0%, #e4e8ee 20%, #e4e8ee 80%, #ffffff 100%); /* FF3.6+ */
@@ -87,6 +86,9 @@ canvas {
 	margin: 34px auto;
 	background: #fff;
 	box-shadow: 2px 2px 8px 0px rgba(0,0,0,0.1);
+	-moz-user-select: none;
+        -webkit-user-select: none;
+        user-select: none;
 }
 
 


### PR DESCRIPTION
``` css
canvas {
  -moz-user-select: none;
  -webkit-user-select: none;
  user-select: none;
}
```

this eliminates the canvas element from being highlighted by the users dragging.
