### PR TITLE
Release entity drag on mouse leave

### DIFF
--- a/js/verlet-1.0.0.js
+++ b/js/verlet-1.0.0.js
@@ -512,7 +512,8 @@ function VerletJS(width, height, canvas) {
 		}
 	};
 	
-	this.canvas.onmouseup = function(e) {
+	this.canvas.onmouseup =
+	this.canvas.onmouseleave = function(e) {
 		_this.mouseDown = false;
 		_this.draggedEntity = null;
 	};


### PR DESCRIPTION
Hi,

As mouse cursor move outside canvas and later re-entering can cause unpredictable and often crude physics movements it could be good to simply release entity drag after leaving canvas. User experience is much smoother with that change.

Best Regards
